### PR TITLE
Fix boot code, add comments, add simple UART implementation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -33,7 +33,7 @@ pub fn build(b: *std.Build) anyerror!void {
         "-serial",             "mon:stdio",
     });
 
-    qemu_cmd.step.dependOn(&kernel.step);
+    qemu_cmd.step.dependOn(b.getInstallStep());
     if (b.args) |args| qemu_cmd.addArgs(args);
     const run_step = b.step("run", "Start the kernel in qemu");
     run_step.dependOn(&qemu_cmd.step);

--- a/src/boot.s
+++ b/src/boot.s
@@ -1,11 +1,16 @@
 .option norvc
 .section .data
+
 .section .text.init
 .global _start
-
 _start:
+  // Get the ID of the currently running hart.
   csrr t0, mhartid
-  bnez t0, 3f
+  // If the hart ID is not 0, then just make the hart spin as we only need one
+  // hart to execute the boot code.
+  bnez  t0, 3f
+  // Clear the SATP CSR as we want to work with physical addresses and while booting
+  // do not want virtual memory enabled.
   csrw satp, zero
 .option push
 .option norelax
@@ -13,30 +18,53 @@ _start:
 .option pop
   la a0, _bss_start
   la a1, _bss_end
+  // Skip clearing the BSS section if the address of _bss_start is greater than
+  // the address of _bss_end.
   bgeu a0, a1, 2f
 
 1:
+  // Clear the BSS section, where a0 is initially the address of _bss_start.
   sd zero, (a0)
   addi a0, a0, 8
   bltu a0, a1, 1b
 
 2:
+  // Load the end of the stack into the stack pointer before we jump to kmain.
   la sp, _stack
+  // Here we set the mstatus CSR with the following bits:
+  // MIE (bit 3) is set to globally enable interrupts
+  // MPIE (bit 7) holds the value of the interrupt-enable bit active prior to the trap,
+  // since we keep interrupts on, this stays set.
+  // MPP (bits 11 and 12) are set to the privilege level we want to return to
+  // when we execute the mret instruction, in this case we set it to 0b11
+  // since we want to stay in machine mode (M-mode).
   li t0, (0b11 << 11) | (1 << 7) | (1 << 3)
   csrw mstatus, t0
+  // Set the address of kmain function in our Zig code to be the program
+  // counter when we return (aka when we execute the mret instruction)
   la t1, kmain
   csrw mepc, t1
+  // Set the address of the trap function in our Zig code to be the trap-handler
+  // It will get invoked whenever we get an exception, for example an interrupt
   la t2, trap
   csrw mtvec, t2
-  li t3, (1 << 3) | (1 << 7) | (1 << 11)
+  // Set the M-mode interrupt enable bits
+  // MSIE (bit 3) is set for software interrupts such as IPIs
+  // (inter-processer interrupts), which will become relevant when using other
+  // harts.
+  // MEIE (bit 11) is set to enable external interrupts from hardware devices
+  // such as an ethernet device or serial UART device.
+  // Note that MTIE is *not* set as the kernel does not handle timer-interrupts
+  // and we want to prevent the situation where the trap entry-point is invoked
+  // before we even get to the kmain entry-point.
+  li t3, (1 << 3) | (1 << 11)
   csrw mie, t3
+  // Finally, we have the return address (ra) to
   la ra, 4f
   mret
 
 3:
-  wfi
-  j 3b
-
 4:
+  // Spin the hart
   wfi
   j 4b

--- a/src/boot.s
+++ b/src/boot.s
@@ -21,7 +21,7 @@ _start:
   bltu a0, a1, 1b
 
 2:
-  la sp, _stack_end
+  la sp, _stack
   li t0, (0b11 << 11) | (1 << 7) | (1 << 3)
   csrw mstatus, t0
   la t1, kmain

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -1,3 +1,22 @@
+const std = @import("std");
+const uart = @import("uart.zig");
+
+// Here we set up a printf-like writer from the standard library by providing
+// a way to output via the UART.
+const Writer = std.io.Writer(u32, error{}, uart_put_str);
+const uart_writer = Writer { .context = 0 };
+
+fn uart_put_str(_: u32, str: []const u8) !usize {
+    for (str) |ch| {
+        uart.put_char(ch);
+    }
+    return str.len;
+}
+
+pub fn println(comptime fmt: []const u8, args: anytype) void {
+    uart_writer.print(fmt ++ "\n", args) catch {};
+}
+
 // This the trap/exception entrypoint, this will be invoked any time
 // we get an exception (e.g if something in the kernel goes wrong) or
 // an interrupt gets delivered.
@@ -8,4 +27,8 @@ export fn trap() callconv(.C) noreturn {
 // This is the kernel's entrypoint which will be invoked by the booting
 // CPU (aka hart) after the boot code has executed.
 export fn kmain() callconv(.C) void {
+    // All we're doing is setting up access to the serial device (UART)
+    // and printing a simple message to make sure the kernel has started!
+    uart.init();
+    println("Zig is running on barebones RISC-V!", .{});
 }

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -1,7 +1,11 @@
+// This the trap/exception entrypoint, this will be invoked any time
+// we get an exception (e.g if something in the kernel goes wrong) or
+// an interrupt gets delivered.
 export fn trap() callconv(.C) noreturn {
     while (true) {}
 }
 
+// This is the kernel's entrypoint which will be invoked by the booting
+// CPU (aka hart) after the boot code has executed.
 export fn kmain() callconv(.C) void {
-    // Kernel entrypoint goes here
 }

--- a/src/linker.lds
+++ b/src/linker.lds
@@ -20,7 +20,7 @@ SECTIONS
     *(.text.init) *(.text .text.*)
     PROVIDE(_text_end = .);
   } >ram AT>ram :text
-  
+
   PROVIDE(_global_pointer = .);
 
   .rodata : {

--- a/src/linker.lds
+++ b/src/linker.lds
@@ -43,9 +43,8 @@ SECTIONS
   } >ram AT>ram :bss
 
   PROVIDE(_memory_start = ORIGIN(ram));
-  PROVIDE(_stack_start = _bss_end);
-  PROVIDE(_stack_end = _stack_start + 0x80000);
+  PROVIDE(_stack = _bss_end + 0x80000);
   PROVIDE(_memory_end = ORIGIN(ram) + LENGTH(ram));
-  PROVIDE(_heap_start = _stack_end);
+  PROVIDE(_heap_start = _stack);
   PROVIDE(_heap_size = _memory_end - _heap_start);
 }

--- a/src/uart.zig
+++ b/src/uart.zig
@@ -1,0 +1,60 @@
+// This is a driver for the NS16550 UART devices. It is based on the OpenSBI NS16550 driver.
+
+// The default UART serial device is at 0x10000000 on the QEMU RISC-V virt platform
+const uart_base: usize = 0x10000000;
+
+const UART_RBR_OFFSET = 0;   // In:  Recieve Buffer Register
+const UART_DLL_OFFSET = 0;   // Out: Divisor Latch Low
+const UART_IER_OFFSET = 1;   // I/O: Interrupt Enable Register
+const UART_DLM_OFFSET = 1;   // Out: Divisor Latch High
+const UART_FCR_OFFSET = 2;   // Out: FIFO Control Register
+const UART_LCR_OFFSET = 3;   // Out: Line Control Register
+const UART_LSR_OFFSET = 5;   // In:  Line Status Register
+const UART_MDR1_OFFSET = 8;  // I/O:  Mode Register
+
+const UART_LSR_DR = 0x01;    // Receiver data ready
+const UART_LSR_THRE = 0x20;  // Transmit-hold-register empty
+
+fn write_reg(offset: usize, value: u8) void {
+    const ptr: *volatile u8 = @ptrFromInt(uart_base + offset);
+    ptr.* = value;
+}
+
+fn read_reg(offset: usize) u8 {
+    const ptr: *volatile u8 = @ptrFromInt(uart_base + offset);
+    return ptr.*;
+}
+
+pub fn put_char(ch: u8) void {
+    // Wait for transmission bit to be empty before enqueuing more characters
+    // to be outputted.
+    while ((read_reg(UART_LSR_OFFSET) & UART_LSR_THRE) == 0) {}
+
+    write_reg(0, ch);
+}
+
+pub fn get_char() ?u8 {
+    // Check that we actually have a character to read, if so then we read it
+    // and return it.
+    if (read_reg(UART_LSR_OFFSET) & UART_LSR_DR == 1) {
+        return read_reg(UART_RBR_OFFSET);
+    } else {
+        return null;
+    }
+}
+
+pub fn init() void {
+    const lcr = (1 << 0) | (1 << 1);
+    write_reg(UART_LCR_OFFSET, lcr);
+    write_reg(UART_FCR_OFFSET, (1 << 0));
+    write_reg(UART_IER_OFFSET, (1 << 0));
+    write_reg(UART_LCR_OFFSET, lcr | (1 << 7));
+
+    const divisor: u16 = 592;
+    const divisor_least: u8 = divisor & 0xff;
+    const divisor_most:  u8 = divisor >> 8;
+    write_reg(UART_DLL_OFFSET, divisor_least);
+    write_reg(UART_DLM_OFFSET, divisor_most);
+
+    write_reg(UART_LCR_OFFSET, lcr);
+}


### PR DESCRIPTION
This PR fixes the boot code to work with the latest version of QEMU, see the 901cb8be5926353a13964fd56e3ac9ee5b28dd8f commit message for details of what happened.

Also adds a bunch of comments to try explain the boot code, and a simple UART driver for outputting to the serial and receiving characters. Although, the UART driver initialisation could use with more comments, might add more in a separate PR.