### PR TITLE
Add support for 32-bit RISC-V

### DIFF
--- a/src/boot.S
+++ b/src/boot.S
@@ -24,7 +24,11 @@ _start:
 
 1:
   // Clear the BSS section, where a0 is initially the address of _bss_start.
+#if __riscv_xlen == 64
   sd zero, (a0)
+#elif __riscv_xlen == 32
+  sw zero, (a0)
+#endif
   addi a0, a0, 8
   bltu a0, a1, 1b
 

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -30,5 +30,6 @@ export fn kmain() callconv(.C) void {
     // All we're doing is setting up access to the serial device (UART)
     // and printing a simple message to make sure the kernel has started!
     uart.init();
-    println("Zig is running on barebones RISC-V!", .{});
+    // Who knows, maybe in the future we'll have rv128...
+    println("Zig is running on barebones RISC-V (rv{})!", .{ @bitSizeOf(usize) });
 }


### PR DESCRIPTION
Given the simplicity of the boot code, it's actually quite easy to add support for RISC-V 32-bit as well as 64-bit!