### PR TITLE
Set trap() alignment to always be 4.

### DIFF
--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -20,7 +20,7 @@ pub fn println(comptime fmt: []const u8, args: anytype) void {
 // This the trap/exception entrypoint, this will be invoked any time
 // we get an exception (e.g if something in the kernel goes wrong) or
 // an interrupt gets delivered.
-export fn trap() callconv(.C) noreturn {
+export fn trap() align(4) callconv(.C) noreturn {
     while (true) {}
 }
 


### PR DESCRIPTION
As per the specification of the UART the last 2 bits of `mtvec` are for the mode and are always disregarded for the address, due to this the trap function must always be aligned to 4. This commit adds this alignment to help prevent hard to track down bugs.

Reference: https://five-embeddev.com/riscv-isa-manual/latest/machine.html#machine-trap-vector-base-address-register-mtvec