### PR TITLE
build: update to zig 0.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-zig-cache/
+.zig-cache/
 zig-out/

--- a/build.zig
+++ b/build.zig
@@ -10,14 +10,14 @@ pub fn build(b: *std.Build) anyerror!void {
     } });
 
     const kernel = b.addExecutable(.{
-        .root_source_file = .{ .path = "src/kernel.zig" },
+        .root_source_file = b.path("src/kernel.zig"),
         .optimize = optimize,
         .target = target,
         .name = "kernel",
         .code_model = .medium,
     });
 
-    kernel.setLinkerScriptPath(.{ .path = "src/linker.lds" });
+    kernel.setLinkerScriptPath(b.path("src/linker.lds"));
     // Some of the boot-code changes depending on if we're targeting 32-bit
     // or 64-bit, which is why we need the pre-processor to run first.
     kernel.addCSourceFiles(.{


### PR DESCRIPTION
Updated the build.zig to zig 0.13 and above. The zig-cache folder got renamed to .zig-cache.
This should also work with 0.12 but it was not tested.